### PR TITLE
Autocomplete for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ No configuration is necessary, although it's possible to change the default dire
 let g:sauce_path = "/path/to/sauces"
 ```
 
-## Known Issues
-
-The autocomplete currently won't work with Windows. However, plans are in place to change that.
-
 ## License
 
 Sauce for Vim is released under the MIT license. See the LICENSE file for more information.

--- a/autoload/sauce.vim
+++ b/autoload/sauce.vim
@@ -72,26 +72,6 @@ function! sauce#SauceDelete(name)
 		echohl Error | echo "Invalid sauce file: ".fname | echohl None
 	endif
 endfunction
-"
-" Delete a sauce file with the given name
-function! sauce#SauceDelete(name)
-	let fname = g:sauce_path.a:name.".".g:sauce_extension
-	if filereadable(fname)
-		let response = confirm("Are you sure you want to delete the sauce '".a:name."'? ","&Yes\n&No",2)
-		if response == 1
-			let delret = delete(fname)
-			if 0 == delret
-				echohl Error | echo "Deleted sauce file: ".fname | echohl None
-			else
-				echohl Error | echo "Failed to delete sauce file: ".fname | echohl None
-			endif
-		else
-			echom "Cancelled delete"
-		endif
-	else
-		echohl Error | echo "Invalid sauce file: ".fname | echohl None
-	endif
-endfunction
 
 " Get all sauces as a list
 function! sauce#SauceNames()
@@ -109,7 +89,7 @@ function! sauce#SauceNames()
 endfunction
 
 " Load a source file
-function sauce#LoadSauce(source)
+function! sauce#LoadSauce(source)
 	let saucefile = g:sauce_path.a:source.".".g:sauce_extension
 	if filereadable(saucefile)
 		if 1 == g:sauce_output

--- a/autoload/sauce.vim
+++ b/autoload/sauce.vim
@@ -76,16 +76,15 @@ endfunction
 " Get all sauces as a list
 function! sauce#SauceNames()
     let l:sources = []
-    if has("unix")
-        let l:findop=system("find ".g:sauce_path." -name \"*.".g:sauce_extension."\" |awk -F/ '{print $NF}'")
-        let l:sourcefiles=split(l:findop,"\n")
-        let l:sourcename = ""
-        for fname in l:sourcefiles
-            let l:sourcename = substitute(fname,".".g:sauce_extension,"","")
-            call add(l:sources,l:sourcename)
-        endfor
-    endif
-	return l:sources
+    let l:sourcefiles=split(globpath(g:sauce_path,"**/*.".g:sauce_extension),"\n")
+    for fname in l:sourcefiles
+        " replace separator for smoother substitution.
+        let l:basepath=substitute(g:sauce_path,"\\","/","g")
+        let l:sourcename=substitute(fname,"\\","/","g")
+        let l:sourcename=substitute(l:sourcename,l:basepath."\\(.*\\).".g:sauce_extension,"\\1","")
+        call add(l:sources,l:sourcename)
+    endfor
+    return l:sources
 endfunction
 
 " Load a source file


### PR DESCRIPTION
Hi, I made some changes to SauceNames() so it can work on windows.
I found that the best way to solve it was to use native functions instead of OS specific system calls.

I had to replace windows separators (lines 101-2) because substitution wasn't working, first because the code adds a '/' at the end of sauce_path, and also because the substitute function is a little picky, didn't know how to escape it well.
I also tried to solve it using fnamemodify() but couldn't make it return the last directory plus filename on full paths (so it didn't work recursively).

I tested it on gvim 7.4 windows 7 and console vim 7.3 on linux.

PD: SauceDelete() was repeated, and added ! to LoadSauce for easy sourcing while editing.

R.
